### PR TITLE
Add async enumerable extension

### DIFF
--- a/FileContextCore/Extensions/QueryableExtensions.cs
+++ b/FileContextCore/Extensions/QueryableExtensions.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+
+namespace FileContextCore.Extensions
+{
+    public static class QueryableExtensions
+    {
+        public static async Task<List<T>> ToListAsync<T>(this IQueryable<T> source, CancellationToken cancellationToken = default)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            var list = new List<T>();
+            await foreach (var element in source.AsAsyncEnumerable().WithCancellation(cancellationToken))
+            {
+                list.Add(element);
+            }
+
+            return list;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `ToListAsync` extension method to help async enumeration

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c38f5d360832b844d3009503b68fc