### PR TITLE
Add async enumerable extension

### DIFF
--- a/FileContextCore/Extensions/QueryableExtensions.cs
+++ b/FileContextCore/Extensions/QueryableExtensions.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace FileContextCore.Extensions
+{
+    public static class QueryableExtensions
+    {
+        public static Task<List<T>> ToListAsync<T>(this IQueryable<T> source, CancellationToken cancellationToken = default)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            return Task.Run(() => source.ToList(), cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `ToListAsync` extension method to help async enumeration
- simplify `ToListAsync` to avoid `IDbAsyncEnumerable` requirement by running synchronous enumeration on a background task

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c38f5d360832b844d3009503b68fc